### PR TITLE
Remove site from external search engines

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,5 +3,7 @@ languageCode = "en-us"
 title = "HCPSS API"
 uglyURLs = true
 
+disableKinds = ["sitemap"]
+
 [outputs]
   page = ["JSON"]

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Remove Hugo’s default XML Sitemap output and add a robots.txt file.
Robots.txt information referenced from http://www.robotstxt.org/