### PR TITLE
Add JSON file to handle 404 error codes

### DIFF
--- a/static/404.json
+++ b/static/404.json
@@ -1,0 +1,6 @@
+{
+  "error": {
+     "code": "404",
+     "message": "Resource not available"
+  }
+}


### PR DESCRIPTION
Our site nginx config is configured to return this 404.json for all "Resource not found" requests.

Addresses #6.