### PR TITLE
Fix WOES acronym

### DIFF
--- a/content/schools/woes.md
+++ b/content/schools/woes.md
@@ -1,5 +1,5 @@
 ---
-acronym: wes
+acronym: woes
 name: Worthington
 full_name: 'Worthington Elementary School'
 primary_color: 'rgb(0, 153, 204)'


### PR DESCRIPTION
While the Worthington ES subdomain is currently in DNS as wes.hcpss.org, the correct acronym is "woes".